### PR TITLE
Fix ds9 download issue

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -147,7 +147,7 @@ RUN sh setup_tempo2.sh && rm setup_tempo2.sh
 # DS9
 RUN mkdir $ASTROPFX/bin &&\
  cd $ASTROPFX/bin &&\
- curl http://ds9.si.edu/download/centos6/ds9.centos6.8.0.tar.gz | tar zxv
+ curl http://ds9.si.edu/download/centos6/ds9.centos6.8.1.tar.gz | tar zxv
 
 # RMFIT
 RUN cd /usr/local/bin &&\


### PR DESCRIPTION
Solution to the issue #5 
It updates the version of ds9 to download as the 6.8.0 one is no longer available at the corresponding server.